### PR TITLE
staint affects painstun (willpower update)

### DIFF
--- a/code/modules/jobs/job_types/roguetown/inquisition/puritan.dm
+++ b/code/modules/jobs/job_types/roguetown/inquisition/puritan.dm
@@ -101,7 +101,7 @@
 	if(H == src)
 		to_chat(src, span_warning("I already torture myself."))
 		return
-	var/painpercent = (H.get_complex_pain() / (H.STAEND * 10)) * 100
+	var/painpercent = (H.get_complex_pain() / (((H.STAEND + H.STAINT) / 2) * 10)) * 100
 	if(H.add_stress(/datum/stressevent/tortured))
 		if(!H.stat)
 			var/static/list/torture_lines = list(
@@ -131,7 +131,7 @@
 	if(H == src)
 		to_chat(src, span_warning("I already torture myself."))
 		return
-	var/painpercent = (H.get_complex_pain() / (H.STAEND * 10)) * 100
+	var/painpercent = (H.get_complex_pain() / (((H.STAEND + H.STAINT) / 2) * 10)) * 100
 	if(H.add_stress(/datum/stressevent/tortured))
 		if(!H.stat)
 			var/static/list/faith_lines = list(

--- a/code/modules/mob/living/carbon/energy_stamina.dm
+++ b/code/modules/mob/living/carbon/energy_stamina.dm
@@ -16,10 +16,7 @@
 	update_health_hud()
 
 /mob/living/proc/update_energy()
-	var/athletics_skill = 0
-	if(mind)
-		athletics_skill = mind.get_skill_level(/datum/skill/misc/athletics)
-	max_energy = (STAEND + athletics_skill) * 100 // ENERGY / BLUE (Average of 1000)
+	max_energy = (STAEND + round(STAINT/3, 0.1)) * 100 // ENERGY / BLUE (Average of 1000)
 	if(cmode)
 		if(!HAS_TRAIT(src, TRAIT_BREADY))
 			energy_add(-2)

--- a/code/modules/mob/living/carbon/human/npc/_npc.dm
+++ b/code/modules/mob/living/carbon/human/npc/_npc.dm
@@ -291,7 +291,7 @@
 				monkey_attack(target)
 				if(flee_in_pain && (target.stat == CONSCIOUS))
 					var/paine = get_complex_pain()
-					if(paine >= ((STAEND * 10)*0.9))
+					if(paine >= ((round((STAEND + STAINT) / 2) * 10)*0.9))
 //						mode = AI_FLEE
 						walk_away(src, target, 5, update_movespeed())
 				return TRUE

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -83,7 +83,7 @@
 	if(HAS_TRAIT(src, TRAIT_NOPAIN))
 		return
 	if(!stat)
-		var/pain_threshold = STAEND * 10
+		var/pain_threshold = round(((STAEND + STAINT) / 2) * 10)
 		if(has_flaw(/datum/charflaw/masochist)) // Masochists handle pain better by about 1 endurance point
 			pain_threshold += 10
 		var/painpercent = get_complex_pain() / pain_threshold
@@ -91,7 +91,7 @@
 
 		if(world.time > mob_timers["painstun"])
 			mob_timers["painstun"] = world.time + 100
-			var/probby = 40 - (STAEND * 2)
+			var/probby = 40 - round(((STAEND + STAINT) / 2) * 2)
 			probby = max(probby, 10)
 			if(lying || IsKnockdown())
 				if(prob(3) && (painpercent >= 80) )

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -128,7 +128,7 @@
 	key_third_person = "bows"
 	message = "bows."
 	message_param = "bows to %t."
-	restraint_check = TRUE
+	restraint_check = TRUEf
 	emote_type = EMOTE_VISIBLE
 
 /mob/living/carbon/human/verb/emote_bow()
@@ -333,7 +333,7 @@
 	. = ..()
 	if(. && iscarbon(user))
 		var/mob/living/carbon/L = user
-		if(L.get_complex_pain() > (L.STAEND * 9))
+		if(L.get_complex_pain() > (round((L.STAEND + L.STAINT) / 2) * 9))
 			L.setDir(2)
 			L.SetUnconscious(200)
 		else

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -95,8 +95,8 @@
 	//random painstun
 	if(!stat && !HAS_TRAIT(src, TRAIT_NOPAINSTUN))
 		if(world.time > mob_timers["painstun"] + 600)
-			if(getBruteLoss() + getFireLoss() >= (STAEND * 10))
-				var/probby = 53 - (STAEND * 2)
+			if(getBruteLoss() + getFireLoss() >= round((((STAEND + STAINT) / 2) * 10)))
+				var/probby = 53 - round(((STAEND + STAINT) / 2) * 2))
 				if(!(mobility_flags & MOBILITY_STAND))
 					probby = probby - 20
 				if(prob(probby))


### PR DESCRIPTION
Теперь интеллект участвует в проках на пеинстан. Это достигается вычислением среднего арифметического между STAEND + STAINT. Кроме того, теперь энергия **(синяя полоска)** зависит не от выносливости и скилла атлетики, а от выносливости и интеллекта. Рассмотрим простой пример:

Есть Джон Полуорк, служащий стражем болот.
Джон Полуорк имеет 3 выносливости (+1 раса, +2 класс, 0 дрифт), 8 интеллекта (-2 раса, 0 класс, 0 дрифт) и навык атлетики 3.

Раньше Джон Полуорк:
- имел порог боли в 130 единиц урона;
- имел шанс в 14% свалится от боли при проверке по таймеру, если пересёк порог;
- имел 1600 энергии.

Сейчас Джон Полуорк:
- имеет порог боли в 105 единиц урона;
- имеет шанс в 19% свалится от боли при проверке по таймеру, если пересёк порог;
- имеет 1560 энергии.

Сразу же уточню, что влияние на энергию классов с более низким и более высоким навыком атлетики будет более заметно. Если бы у Джона Полуорка была атлетика 6, то раньше он имел бы 1900 энергии.

Цель ПРа - добавить интеллекту, который является одним из самых бесполезных статов в игре (если ты играешь не крафтера) немного применения, а следовательно - усложнить минмакс. Для разных щитспавн огров/кастомных антагов с 1 интеллекта всё ещё можно использовать TRAIT_NOPAINSTUN.