### PR TITLE
elfd buff

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfd.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfd.dm
@@ -60,16 +60,18 @@
 		"perception" = -1,
 		"intelligence" = 0,
 		"constitution" = 0,
-		"endurance" = 1,
+		"endurance" = 2,
 		"speed" = 1,
 		"fortune" = 0
 		)
 	specstats_m = list(
 		"strength" = -1,
-		"speed" = 1,
+		"intelligence" = 2,
+		"speed" = 2,
 	)
 	specstats_f = list(
-		"constitution" = 1,
+		"strength" = 2,
+		"constitution" = 3,
 		"intelligence" = -1,
 	)
 	enflamed_icon = "widefire"


### PR DESCRIPTION
плотно накидывает тёмным эльфам статов (+1 эндюры для всех, +2 силы +2 консты для женщин, +2 инты +2 скорости для мужчин) поверх бывших. причина - оффы добавили всратейший дебафф, но ничего не дали взамен.