### PR TITLE
removes stat drift

### DIFF
--- a/code/modules/mob/living/stats.dm
+++ b/code/modules/mob/living/stats.dm
@@ -43,9 +43,6 @@
 	STAEND = 10
 	STASPD = 10
 	STALUC = 10
-	for(var/S in MOBSTATS)
-		var/how_much = pick(-1, 0, 1)
-		change_stat(S, how_much)
 	if(ishuman(src))
 		var/mob/living/carbon/human/H = src
 		if(H.dna.species)


### PR DESCRIPTION
удаляет дрифт статов. автор нароллил -1 в каждый стат и очень зол. мб позже сделаю так, что дрифт статов будет только по желанию в префпанеле