### PR TITLE
implements toggleable stat drift

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -160,6 +160,7 @@ GLOBAL_LIST_INIT(name_adjustments, list())
 	var/list/custom_descriptors = list()
 	var/defiant = TRUE
 	var/virginity = FALSE
+	var/drift = FALSE
 	var/char_accent = "No accent"
 	var/datum/loadout_item/loadout
 	/// Tracker to whether the person has ever spawned into the round, for purposes of applying the respawn ban
@@ -714,6 +715,7 @@ GLOBAL_LIST_INIT(name_adjustments, list())
 	dat += "<td width='33%' align='right'>"
 	dat += "<b>Be defiant:</b> <a href='?_src_=prefs;preference=be_defiant'>[(defiant) ? "Yes":"No"]</a><br>"
 	dat += "<b>Be a virgin:</b> <a href='?_src_=prefs;preference=be_virgin'>[(virginity) ? "Yes":"No"]</a><br>"
+	dat += "<b>Stat drift:</b> <a href='?_src_=prefs;preference=stat_drift'>[(drift) ? "Enabled":"Disabled"]</a><br>"
 	dat += "<b>Be voice:</b> <a href='?_src_=prefs;preference=schizo_voice'>[(toggles & SCHIZO_VOICE) ? "Enabled":"Disabled"]</a>"
 	dat += "</td>"
 	dat += "</tr>"
@@ -1959,6 +1961,13 @@ Slots: [job.spawn_positions]</span>
 					else
 						to_chat(user, span_notice("You have. In a word. Fucked before.")) //Someone word this better please kitty is high and words are hard
 
+				if("stat_drift")
+					drift = !drift
+					if(drift)
+						to_chat(user, span_notice("Позволь воле случая вершить твою историю и, возможно, окажешься в плюсе."))
+					else
+						to_chat(user, span_notice("Ты можешь быть слабаком, но какая разница, если залог победы - не дать богам бросить кости?"))
+
 				if("schizo_voice")
 					toggles ^= SCHIZO_VOICE
 					if(toggles & SCHIZO_VOICE)
@@ -2102,6 +2111,7 @@ Slots: [job.spawn_positions]</span>
 	character.backpack = backpack
 	character.defiant = defiant
 	character.virginity = virginity
+	character.drift = drift
 
 	character.jumpsuit_style = jumpsuit_style
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -364,6 +364,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["feature_mcolor3"]					>> features["mcolor3"]
 	S["feature_ethcolor"]					>> features["ethcolor"]
 	S["virginity"]							>> virginity
+	S["drift"]								>> drift
 
 /datum/preferences/proc/load_character(slot)
 	if(!path)
@@ -501,6 +502,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	validate_body_markings()
 
 	virginity = sanitize_integer(virginity, FALSE, TRUE, FALSE)
+	drift = sanitize_integer(drift, FALSE, TRUE, TRUE)
 	if(!family_species)
 		family_species = list()
 	if(isnull(family))
@@ -574,6 +576,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	//virginity
 	WRITE_FILE(S["virginity"], virginity)
+
+	WRITE_FILE(S["drift"], drift)
 	
 	WRITE_FILE(S["family"]							, family)
 	WRITE_FILE(S["family_species"]					, family_species)

--- a/code/modules/mob/living/stats.dm
+++ b/code/modules/mob/living/stats.dm
@@ -35,6 +35,9 @@
 	new_patron.on_gain(src)
 	return TRUE
 
+/mob/living
+	var/drift = TRUE
+
 /mob/living/proc/roll_stats()
 	STASTR = 10
 	STAPER = 10
@@ -43,9 +46,10 @@
 	STAEND = 10
 	STASPD = 10
 	STALUC = 10
-	for(var/S in MOBSTATS)
-		var/how_much = pick(-1, 0, 1)
-		change_stat(S, how_much)
+	if(drift)
+		for(var/S in MOBSTATS)
+			var/how_much = pick(-1, 0, 1)
+			change_stat(S, how_much)
 	if(ishuman(src))
 		var/mob/living/carbon/human/H = src
 		if(H.dna.species)


### PR DESCRIPTION
добавляет возможность включить и отключить статдрифт: собственно, при выключенном статдрифте не будет рандомного сдвига каждого статов от -1 и до +1, все будут 0. теперь игрок может выбирать, стоит ли ему рисковать в прыжке за говядиной, либо просто прыгнуть к курице

пруф оф тест:

**СТАТДРИФТ ВЫКЛЮЧЕН:**
итерация 1:
![image](https://github.com/user-attachments/assets/a22e222a-6c23-4e87-8fed-f293b870dcaa)

итерация 2:
![image](https://github.com/user-attachments/assets/ef5e0cb2-0766-4d0f-9afa-5c8be1da9cd1)

на изображениях видно, что статы не поменялись, они диктуются исключительно ролью, расой и дебаффом на жажду, который какого-то хуя возникает в начале геймплея и вообще блядь кто это кодил и зачем

**СТАТДРИФТ ВКЛЮЧЕН:**
![image](https://github.com/user-attachments/assets/4e66117d-b253-4027-9cba-22e184a961bd)

ну тут наглядно демонстрируется что и статодрифт работает, статов нарандомило, огооо +1 сила повезло повезло

вот кнопочка в префах:
![image](https://github.com/user-attachments/assets/40399038-4c3e-4af1-bff1-326dc2f0ce2c)

ну да возможно быдлокод немного но мне в целом похуй поскольку вся кодбаза такая епт главное что работает