### PR TITLE
Courtiers joinlate window fix

### DIFF
--- a/code/modules/jobs/job_types/roguetown/courtier/butler.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/butler.dm
@@ -3,6 +3,7 @@
 	f_title = "Head Maid"
 	flag = BUTLER
 	department_flag = COURTIERS
+	selection_color = JCOLOR_COURTIER
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -73,8 +73,8 @@ GLOBAL_LIST_INIT(noble_positions, list(
 ))
 
 GLOBAL_LIST_INIT(courtier_positions, list(
+	"Head Butler", // must always stay at the first position of the list
 	"Jester",
-	"Head Butler",
 ))
 
 GLOBAL_LIST_INIT(garrison_positions, list(


### PR DESCRIPTION
## About The Pull Request
Мой фикс joinlate окна с придворными. Мы обговаривали это, Владмар [сказал](https://discord.com/channels/1133928966915358822/1322999657843921010/1336416371377963118) что конфликтов не будет при идентичности ПРов. Прикладываю написанныйна оффах changelog лист:
1. Jobs in the `courtier_positions` list were shuffled in order to put Butler at the top, in `code\modules\jobs\jobs.dm`.
2. Head Butler role got courtier JCOLOR in `code\modules\jobs\job_types\roguetown\courtier\butler.dm`

## Proof of Testing (Required)
![fixed](https://github.com/user-attachments/assets/f5df05d4-a410-487c-8ff6-a7983d9b1eb9)

