### PR TITLE
[ФИКС | РЕБАЛАНС] Шитьё и разбор шёлка; var для шёлка; пересмотр разборного материала одежды 

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -222,6 +222,9 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/e
 	/// Temporary snowflake var to be used in the rare cases clothing doesn't require fibers to sew, to avoid material duping
 	var/fiber_salvage = FALSE
 
+	/// Var to be used in silk crafts, useful for sewing recipies "cloth+silk" (fiber_salvage covered "cloth+fiber" sewing)
+	var/silk_salvage = FALSE
+
 	/// Number of torn sleves, important for salvaging calculations and examine text
 	var/torn_sleeve_number = 0
 

--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -189,6 +189,8 @@
 				return
 			if(item.fiber_salvage) //We're getting fiber as base if fiber is present on the item
 				new /obj/item/natural/fibers(get_turf(item))
+			if(item.silk_salvage) //Getting silk if it is present on the item
+				new /obj/item/natural/silk(get_turf(item))
 			if(istype(item, /obj/item/storage))
 				var/obj/item/storage/bag = item
 				bag.emptyStorage()

--- a/code/modules/clothing/rogueclothes/armor.dm
+++ b/code/modules/clothing/rogueclothes/armor.dm
@@ -407,6 +407,7 @@
 	armor_class = ARMOR_CLASS_LIGHT
 	allowed_sex = list(MALE, FEMALE)
 	allowed_race = CLOTHED_RACES_TYPES
+	silk_salvage = TRUE
 	salvage_result = /obj/item/natural/fur
 
 /obj/item/clothing/suit/roguetown/armor/silkcoat/Initialize()
@@ -525,4 +526,5 @@
 	max_integrity = 300
 	sellprice = 40
 	armor_class = ARMOR_CLASS_LIGHT
+	silk_salvage = TRUE
 

--- a/code/modules/clothing/rogueclothes/cloaks.dm
+++ b/code/modules/clothing/rogueclothes/cloaks.dm
@@ -946,7 +946,8 @@
 	allowed_race = NON_DWARVEN_RACE_TYPES
 	flags_inv = null
 	w_class = WEIGHT_CLASS_SMALL
-	salvage_amount = 1
+	silk_salvage = TRUE
+	salvage_amount = 0
 
 /obj/item/clothing/cloak/half/ComponentInitialize()
 	. = ..()

--- a/code/modules/clothing/rogueclothes/hats/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats/hats.dm
@@ -157,6 +157,8 @@
 	adjustable = CAN_CADJUST
 	toggle_icon_state = TRUE
 	max_integrity = 100
+	fiber_salvage = FALSE
+	silk_salvage = TRUE
 
 /obj/item/clothing/head/roguetown/roguehood/nochood
 	name = "лунный капюшон"
@@ -173,6 +175,8 @@
 	adjustable = CAN_CADJUST
 	toggle_icon_state = TRUE
 	max_integrity = 100
+	fiber_salvage = FALSE
+	silk_salvage = TRUE
 
 /obj/item/clothing/head/roguetown/necrahood
 	name = "вуаль смерти"
@@ -182,6 +186,8 @@
 	item_state = "necrahood"
 	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	dynamic_hair_suffix = ""
+	fiber_salvage = FALSE
+	silk_salvage = TRUE
 
 /obj/item/clothing/head/roguetown/dendormask
 	name = "маска друидов"

--- a/code/modules/clothing/rogueclothes/mask.dm
+++ b/code/modules/clothing/rogueclothes/mask.dm
@@ -132,6 +132,8 @@
 	toggle_icon_state = TRUE
 	experimental_onhip = TRUE
 	sewrepair = TRUE
+	fiber_salvage = FALSE
+	silk_salvage = TRUE
 	salvage_amount = 1
 
 /obj/item/clothing/mask/rogue/shepherd/AdjustClothes(mob/user)
@@ -182,3 +184,4 @@
 	dynamic_hair_suffix = ""
 	flags_inv = HIDEFACE | HIDEFACIALHAIR
 	resistance_flags = FIRE_PROOF
+	smeltresult = /obj/item/ingot/silver

--- a/code/modules/clothing/rogueclothes/new/cloaks.dm
+++ b/code/modules/clothing/rogueclothes/new/cloaks.dm
@@ -11,6 +11,7 @@
 	nodismemsleeves = TRUE
 	inhand_mod = TRUE
 	toggle_icon_state = FALSE
+	silk_salvage = TRUE
 	salvage_result = /obj/item/natural/silk
 
 /obj/item/clothing/cloak/shadow/ComponentInitialize()

--- a/code/modules/clothing/rogueclothes/new/gloves.dm
+++ b/code/modules/clothing/rogueclothes/new/gloves.dm
@@ -11,7 +11,9 @@
 	max_integrity = 150
 	break_sound = 'sound/foley/cloth_rip.ogg'
 	drop_sound = 'sound/foley/dropsound/cloth_drop.ogg'
-	salvage_result = /obj/item/natural/silk
+	fiber_salvage = FALSE
+	silk_salvage = TRUE
+	salvage_amount = 1
 
 /obj/item/clothing/gloves/roguetown/wrap
 	name = "тканевые обмотки для рук"

--- a/code/modules/clothing/rogueclothes/new/pants.dm
+++ b/code/modules/clothing/rogueclothes/new/pants.dm
@@ -12,5 +12,5 @@
 	blade_dulling = DULLING_BASHCHOP
 	r_sleeve_status = SLEEVE_NORMAL
 	l_sleeve_status = SLEEVE_NORMAL
-	salvage_amount = 1
 	salvage_result = /obj/item/natural/silk
+	salvage_amount = 3

--- a/code/modules/clothing/rogueclothes/new/shirts.dm
+++ b/code/modules/clothing/rogueclothes/new/shirts.dm
@@ -32,4 +32,3 @@
 	l_sleeve_status = SLEEVE_NORMAL
 	silk_salvage = TRUE
 	salvage_result = /obj/item/natural/silk
-	salvage_amount = 2

--- a/code/modules/clothing/rogueclothes/new/shirts.dm
+++ b/code/modules/clothing/rogueclothes/new/shirts.dm
@@ -30,3 +30,6 @@
 	icon_state = "shadowrobe"
 	r_sleeve_status = SLEEVE_NORMAL
 	l_sleeve_status = SLEEVE_NORMAL
+	silk_salvage = TRUE
+	salvage_result = /obj/item/natural/silk
+	salvage_amount = 2

--- a/code/modules/clothing/rogueclothes/pants.dm
+++ b/code/modules/clothing/rogueclothes/pants.dm
@@ -93,7 +93,10 @@
 	item_state = "webs"
 	r_sleeve_status = SLEEVE_NOMOD
 	l_sleeve_status = SLEEVE_NOMOD
+	fiber_salvage = FALSE
+	silk_salvage = TRUE
 	salvage_result = /obj/item/natural/silk
+	salvage_amount = 1
 
 /obj/item/clothing/under/roguetown/trou
 	name = "рабочие брюки"

--- a/code/modules/clothing/rogueclothes/robes.dm
+++ b/code/modules/clothing/rogueclothes/robes.dm
@@ -28,6 +28,7 @@
 	r_sleeve_status = SLEEVE_NORMAL
 	l_sleeve_status = SLEEVE_NORMAL
 	ignore_sleeves_code = TRUE // No sleeves, otherwise arms will be over the sprite
+	silk_salvage = TRUE
 
 /obj/item/clothing/suit/roguetown/shirt/robe/noc
 	slot_flags = ITEM_SLOT_ARMOR
@@ -43,6 +44,7 @@
 	r_sleeve_status = SLEEVE_NORMAL
 	l_sleeve_status = SLEEVE_NORMAL
 	ignore_sleeves_code = TRUE // No sleeves, otherwise arms will be over the sprite
+	silk_salvage = TRUE
 
 /obj/item/clothing/suit/roguetown/shirt/robe/necromancer
 	slot_flags = ITEM_SLOT_ARMOR
@@ -73,6 +75,7 @@
 	r_sleeve_status = SLEEVE_NORMAL
 	l_sleeve_status = SLEEVE_NORMAL
 	ignore_sleeves_code = TRUE // No sleeves, otherwise arms will be over the sprite
+	silk_salvage = TRUE
 
 /obj/item/clothing/suit/roguetown/shirt/robe/necra
 	slot_flags = ITEM_SLOT_ARMOR
@@ -87,6 +90,7 @@
 	color = null
 	r_sleeve_status = SLEEVE_NORMAL
 	l_sleeve_status = SLEEVE_NORMAL
+	silk_salvage = TRUE
 
 /obj/item/clothing/suit/roguetown/shirt/robe/black
 	color = "#222222"
@@ -191,6 +195,7 @@
 	flags_inv = HIDEBOOB|HIDECROTCH
 	r_sleeve_status = SLEEVE_NORMAL
 	l_sleeve_status = SLEEVE_NORMAL
+	silk_salvage = TRUE
 	var/fanatic_wear = FALSE
 
 /obj/item/clothing/suit/roguetown/shirt/robe/eora/alt

--- a/code/modules/clothing/rogueclothes/shirts.dm
+++ b/code/modules/clothing/rogueclothes/shirts.dm
@@ -235,6 +235,8 @@
 	icon_state = "silkdress"
 	item_state = "silkdress"
 	color = "#e6e5e5"
+	silk_salvage = TRUE
+	salvage_result = /obj/item/natural/silk = 2
 
 /obj/item/clothing/suit/roguetown/shirt/dress/silkdress/black
 	color = CLOTHING_BLACK
@@ -260,6 +262,8 @@
 	icon_state = "velvetdress"
 	item_state = "velvetdress"
 	ignore_sleeves_code = TRUE // No sleeves, otherwise arms will be over the sprite
+	salvage_result = /obj/item/natural/silk
+	salvage_amount = 4
 
 /obj/item/clothing/suit/roguetown/shirt/dress/velvetdress/black
 	color = CLOTHING_BLACK
@@ -285,6 +289,8 @@
 	icon_state = "nobledress"
 	item_state = "nobledress"
 	ignore_sleeves_code = TRUE // No sleeves, otherwise arms will be over the sprite
+	silk_salvage = TRUE
+	salvage_amount = 4
 
 /obj/item/clothing/suit/roguetown/shirt/dress/nobledress/black
 	color = CLOTHING_BLACK
@@ -306,6 +312,7 @@
 	sleevetype = null
 	sleeved = null
 	color = "#a90707"
+	salvage_amount = 6
 
 /obj/item/clothing/suit/roguetown/shirt/dress/gen/sexy/Initialize()
 	. = ..()
@@ -324,7 +331,8 @@
 	l_sleeve_status = SLEEVE_NORMAL
 	body_parts_covered = CHEST|ARMS|VITALS
 	color = null
-	salvage_amount = 1
+	fiber_salvage = FALSE
+	silk_salvage = TRUE
 	salvage_result = /obj/item/natural/silk
 
 /obj/item/clothing/suit/roguetown/shirt/jester

--- a/code/modules/clothing/rogueclothes/shirts.dm
+++ b/code/modules/clothing/rogueclothes/shirts.dm
@@ -213,6 +213,7 @@
 	icon_state = "dressgen"
 	item_state = "dressgen"
 	color = "#6b5445"
+	silk_salvage = TRUE
 
 /obj/item/clothing/suit/roguetown/shirt/dress/gen/black
 	color = CLOTHING_BLACK

--- a/code/modules/clothing/rogueclothes/shirts.dm
+++ b/code/modules/clothing/rogueclothes/shirts.dm
@@ -236,7 +236,7 @@
 	item_state = "silkdress"
 	color = "#e6e5e5"
 	silk_salvage = TRUE
-	salvage_result = /obj/item/natural/silk = 2
+	salvage_result = /obj/item/natural/silk
 
 /obj/item/clothing/suit/roguetown/shirt/dress/silkdress/black
 	color = CLOTHING_BLACK
@@ -364,6 +364,8 @@
 	l_sleeve_status = SLEEVE_NORMAL
 	var/picked = FALSE
 	colorgrenz = TRUE
+	salvage_result = /obj/item/natural/silk
+	salvage_amount = 4
 
 /obj/item/clothing/suit/roguetown/shirt/grenzelhoft/attack_right()
 	..()

--- a/code/modules/roguetown/roguecrafting/sewing.dm
+++ b/code/modules/roguetown/roguecrafting/sewing.dm
@@ -752,10 +752,10 @@
 				/obj/item/natural/silk = 1)
 	skill_level = 1
 
-/datum/crafting_recipe/roguetown/sewing/rags
-	name = "рубашка-паутинка - (1 шелк; НОВИЧОК)"
+/datum/crafting_recipe/roguetown/sewing/webs
+	name = "рубашка-паутинка (3 шелка; НОВИЧОК)"
 	result = list(/obj/item/clothing/suit/roguetown/shirt/undershirt/webs)
-	reqs = list(/obj/item/natural/silk = 1)
+	reqs = list(/obj/item/natural/silk = 3)
 	skill_level = 1
 
 /datum/crafting_recipe/roguetown/sewing/webbing
@@ -783,16 +783,16 @@
 				/obj/item/natural/silk = 1)
 	skill_level = 3
 
-/datum/crafting_recipe/roguetown/sewing/nochood
-	name = "капюшон Нок - (2 ткани, 1 шелк; УМЕЛЕЦ)"
-	result = list(/obj/item/clothing/head/roguetown/roguehood/nochood)
+/datum/crafting_recipe/roguetown/sewing/necrahood
+	name = "вуаль Некры - (2 ткани, 1 шелк; УМЕЛЕЦ)"
+	result = list(/obj/item/clothing/head/roguetown/necrahood)
 	reqs = list(/obj/item/natural/cloth = 2,
 				/obj/item/natural/silk = 1)
 	skill_level = 3
 
-/datum/crafting_recipe/roguetown/sewing/necrahood
-	name = "капюшон Некры - (2 ткани, 1 шелк; УМЕЛЕЦ)"
-	result = list(/obj/item/clothing/head/roguetown/necrahood)
+/datum/crafting_recipe/roguetown/sewing/nochood
+	name = "капюшон Нок - (2 ткани, 1 шелк; УМЕЛЕЦ)"
+	result = list(/obj/item/clothing/head/roguetown/roguehood/nochood)
 	reqs = list(/obj/item/natural/cloth = 2,
 				/obj/item/natural/silk = 1)
 	skill_level = 3
@@ -811,13 +811,6 @@
 				/obj/item/natural/silk = 3)
 	skill_level = 3
 	sellprice = 75
-
-/datum/crafting_recipe/roguetown/sewing/eorarobes
-	name = "эоранская ряса - (3 ткани, 1 шелк; УМЕЛЕЦ)"
-	result = list(/obj/item/clothing/suit/roguetown/shirt/robe/eora)
-	reqs = list(/obj/item/natural/cloth = 3,
-				/obj/item/natural/silk = 1)
-	skill_level = 3
 
 /datum/crafting_recipe/roguetown/sewing/shirt
 	name = "рубаха из шелка - (5 шелка; УМЕЛЕЦ)"
@@ -858,6 +851,13 @@
 /datum/crafting_recipe/roguetown/sewing/dendorrobe
 	name = "одеяние Дендора - (3 ткани, 1 шелк; ПРОФЕССИОНАЛ)"
 	result = list(/obj/item/clothing/suit/roguetown/shirt/robe/dendor)
+	reqs = list(/obj/item/natural/cloth = 3,
+				/obj/item/natural/silk = 1)
+	skill_level = 4
+
+/datum/crafting_recipe/roguetown/sewing/eorarobes
+	name = "эоранская ряса - (3 ткани, 1 шелк; ПРОФЕССИОНАЛ)"
+	result = list(/obj/item/clothing/suit/roguetown/shirt/robe/eora)
 	reqs = list(/obj/item/natural/cloth = 3,
 				/obj/item/natural/silk = 1)
 	skill_level = 4

--- a/code/modules/roguetown/roguecrafting/sewing.dm
+++ b/code/modules/roguetown/roguecrafting/sewing.dm
@@ -813,9 +813,10 @@
 	sellprice = 75
 
 /datum/crafting_recipe/roguetown/sewing/shirt
-	name = "рубаха из шелка - (5 шелка; УМЕЛЕЦ)"
+	name = "рубаха из шелка - (1 ткань, 4 шелка; УМЕЛЕЦ)"
 	result = list(/obj/item/clothing/suit/roguetown/shirt/grenzelhoft)
-	reqs = list(/obj/item/natural/silk = 5)
+	reqs = list(/obj/item/natural/cloth = 1,
+				/obj/item/natural/silk = 4)
 	skill_level = 3
 
 /* craftdif of 4 = EXPERT */
@@ -828,7 +829,7 @@
 	skill_level = 4
 
 /datum/crafting_recipe/roguetown/sewing/shadowcloak
-	name = "плащ авангарда - (1 ткань, 3 шелка; ПРОФЕССИОНАЛ)"
+	name = "плащ авангарда - (2 ткани, 3 шелка; ПРОФЕССИОНАЛ)"
 	result = list(/obj/item/clothing/cloak/shadow)
 	reqs = list(/obj/item/natural/cloth = 2,
 				/obj/item/natural/silk = 3)
@@ -856,7 +857,7 @@
 	skill_level = 4
 
 /datum/crafting_recipe/roguetown/sewing/eorarobes
-	name = "эоранская ряса - (3 ткани, 1 шелк; ПРОФЕССИОНАЛ)"
+	name = "ряса Эоры - (3 ткани, 1 шелк; ПРОФЕССИОНАЛ)"
 	result = list(/obj/item/clothing/suit/roguetown/shirt/robe/eora)
 	reqs = list(/obj/item/natural/cloth = 3,
 				/obj/item/natural/silk = 1)

--- a/modular/code/game/objects/items/clothes/stockings.dm
+++ b/modular/code/game/objects/items/clothes/stockings.dm
@@ -42,6 +42,7 @@
 
 /obj/item/clothing/under/roguetown/tights/stockings/silk/white
 	color = "#e6e5e5"
+	silk_salvage = TRUE
 
 /obj/item/clothing/under/roguetown/tights/stockings/silk/black
 	color = CLOTHING_BLACK

--- a/modular/code/game/objects/items/clothes/stockings.dm
+++ b/modular/code/game/objects/items/clothes/stockings.dm
@@ -35,6 +35,7 @@
 	name = "шелковые чулки"
 	desc = "Чулки, созданные только для чистой эстетики. Изготовлены из тончайшего шелка. Популярны среди богатых и влиятельных женщин."
 	icon_state = "silk"
+	silk_salvage = TRUE
 
 /obj/item/clothing/under/roguetown/tights/stockings/silk/random/Initialize()
 	. = ..()
@@ -42,7 +43,6 @@
 
 /obj/item/clothing/under/roguetown/tights/stockings/silk/white
 	color = "#e6e5e5"
-	silk_salvage = TRUE
 
 /obj/item/clothing/under/roguetown/tights/stockings/silk/black
 	color = CLOTHING_BLACK

--- a/modular_twilight/code/modules/roguetown/roguecrafting/sewing.dm
+++ b/modular_twilight/code/modules/roguetown/roguecrafting/sewing.dm
@@ -52,7 +52,7 @@
 	skill_level = 3
 
 /datum/crafting_recipe/roguetown/sewing/abyssortemplartabard
-	name = "табард рыцаря Абиссора - (3 ткани, 1 волокно; УМЕЛЕЦ)"
+	name = "табард Абиссора - (3 ткани, 1 волокно; УМЕЛЕЦ)"
 	result = list(/obj/item/clothing/cloak/abyssortabard)
 	reqs = list(/obj/item/natural/cloth = 3,
 				/obj/item/natural/fibers = 1)


### PR DESCRIPTION
## About The Pull Request
Здесь будет чейнджлог:
- В `code\game\objects\items.dm` был добавлен `var/silk_salvage = FALSE`
   - Он идентичен `var/fiber_salvage` и помещён в `rogueweapons\melee\knives.dm` в участке кода, дающем волокно при разборе ножницами. Это откомментировано. Теперь шёлковые вещи с этим var = true дадут 1 шёлк.
   - `silk_salvage = TRUE` был применён к почти всем вещам с участием шёлка в их крафте.
- Была перебрана вся одежда с участием шёлка в создании в `roguecrafting\sewing.dm`. Из технического:
   - Был исправлен эксплойт шёлка рубашки-паутинки, которая создавалась из 1-го шёлка и могла быть порвана, рукавами, на два шёлка, then repeat.
   - Рубашка паутинка делила путь крафта `/datum/crafting_recipe/roguetown/sewing/rags` между собой и тряпьем. Паутинка получила путь `/sewing/webs` . 
   - Эоранская ряса перенесена из крафтов 3-го уровня в крафты 4-го уровня к своим "сёстрам".
- Переименования:
   - `капюшон Некры` --> `вуаль Некры`.
   - `эоранская ряса` --> `ряса Эоры`, созвучно соседям: `одеяния Астраты/Дендора/Некры/Нок`.
   - `табард рыцаря Абиссора` --> `табард Абиссора`, тождественно другим табардам.
- Прочее:
   - Эоранская маска теперь может быть переплавлена в слиток серебра.
   - Фикс названия: плащ авангарда требует 2 ткани, название крафта требовало 1 ткань.

### Под нижележащим спойлером предоставлен полный чейнджлог изменений крафта
<details> 
<summary>Open Spoiler</summary>
Изменения касаются кол-ва материалов при salvage и что это за материал. <br/>
Если не указано иначе, предмет имеет silk_salvage = TRUE и дропает 1 шёлк при разборе.<br/>
Если не указано иначе, предмет имеет fiber_salvage = TRUE и дропает 1 волокно при разборе.<br/>
<br/>
<ul>
<li>
<b>Шелковая полумаска</b>. Материала при разборе: 1. Не дропает волокно.
</li>
<li>
<b>Рубашка-паутинка</b>. Требует 3 шёлка вместо 1. Материала при разборе: 2. Материал: шёлк.
</li>
<li>
<b>Перепончатые штаны из шелка</b>. Материала при разборе: 1. Материал: шёлк. Не дропают волокно.
</li>
<li>
<b>Перчатки из шелка</b>. Материала при разборе: 1. Не дропают волокно.
</li>
<li>
<b>Полуплащ из шелка</b>. Материала при разборе: 0. Расчёт утерять 1 волокно и сохранить шелк.
</li>
<li>
<b>Вуаль Некры, Капюшон Нок/Астраты</b>. Не дропают волокно.
</li>
<li>
<b>Шелковая рубашка</b>. Требует 4 шёлка и 1 ткань вместо 5 шёлка. Материала при разборе: 4. Материал: шёлк. Не дропает шёлк.
</li>
<li>
<b>Брюки из шелка</b>. Материала при разборе: 3. Материал: шёлк. Не дропают шёлк.
</li>
<li>
<b>Плащ авангарда</b>. Материал: шелк. Утеря 3-х волокон ради 1 гарантированного шёлка и ещё 2 при разборе.
</li>
<li>
<b>Униформа авангарда</b>. Материал: шёлк. Аналогично плащу.
</li>
<li>
<b>Одеяния аколитов по богам</b>. Гарантировано дропают шёлк. Гарантирована утеря минимум 1 волокна. 
</li>
<li>
<b>Куртка Новолуния. Пальто из шелка. Шелковые чулки</b>. Дропает 1 шёлк.
</li>
<li>
<b>Платье-сорочка (шелк)</b>. Материал: шёлк. 
</li>
<li>
<b>Бархатное платье</b>. Материала при разборе: 4. Материал: шёлк.
</li>
<li>
<b>Дворянское платье</b>. Материала при разборе: 4. 
</li>
</ul>
Стоит помнить, что, без изменений переменных, одежда всегда дропает 2 ткани и 1 волокно. <br/>
</details>

## Why It's Good For The Game
Введение нового var позволит гарантировано получать шёлк, волокно и ткани/мех в сложных рецептах, а также сделать гарантию возвращения части шёлка при возможной утрате его части, если будет низкий навык. Взамен идёт трата куда более дешёвых волокон, из расчёта что портной будет стараться извлечь именно шёлк. Единственным убыточным по шёлку при разборе остаётся лишь барное платье.

Ручной перебор количества материалов позволит убрать парочку эксплойтов бесконечного шёлка. в частности на рубашке-паутинке, через рукава. Новый крафт рубахи из шёлка выглядит логичнее ввиду описания (Сделанная из только шёлка рубаха-паутинка описывается как "Всё равно что носить паутину", а гренцельхофтская - элегантна).

Переводы делались из соображения тождественности звучания к уже имеющемуся массиву иных предметов (Табард и ряса). Капюшон Некры при крафте становится "Вуалью Смерти", не имеет механа капюшона и выглядит как мешок на голову, ввиду чего будет назван Вуалью.

Я кодил это глубокой ночью и рекомендую ревью файлов сделать, включая то, балансны ли изменения.

## Proof of Testing (Required)
![debug](https://github.com/user-attachments/assets/c07a8916-7fff-4d75-bd27-9c6db6180803)

https://github.com/user-attachments/assets/54792db8-2f5d-4359-a0d4-d2a56b99f31f