### PR TITLE
[BUGFIX] Починка зунари кабуто

### DIFF
--- a/modular_twilight/code/modules/clothing/izuma/hats.dm
+++ b/modular_twilight/code/modules/clothing/izuma/hats.dm
@@ -236,7 +236,7 @@
 	armor = list("blunt" = 90, "slash" = 100, "stab" = 80, "bullet" = 100, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	body_parts_covered = HEAD|HAIR|NOSE|EARS|EYES
 
-/obj/item/clothing/head/roguetown/zurarikabutonew
+/obj/item/clothing/head/roguetown/helmet/zurarikabutonew
 	name = "зунари кабуто Изумы"
 	desc = "Кабуто этчу дзунари с маркировкой Изумы. У него нет демонической\
 	маски для устрашения - но она остается такой же эффективной, к тому же демонстрирует\

--- a/modular_twilight/code/modules/clothing/izuma/mercenary/samurai.dm
+++ b/modular_twilight/code/modules/clothing/izuma/mercenary/samurai.dm
@@ -29,7 +29,7 @@
 	beltr = /obj/item/rogueweapon/sword/short/wakizashi
 	neck = /obj/item/clothing/neck/roguetown/chaincoif/iron/kusari_zukin //
 	shirt = /obj/item/clothing/suit/roguetown/shirt/tunic/kimono //
-	head = /obj/item/clothing/head/roguetown/zurarikabutonew //
+	head = /obj/item/clothing/head/roguetown/helmet/zurarikabutonew //
 	armor = /obj/item/clothing/suit/roguetown/armor/brigandine/oyoroi/oyoroigusoku //
 	pants = /obj/item/clothing/under/roguetown/chainlegs/sendan //
 	shoes = /obj/item/clothing/shoes/roguetown/boots/armor/light/kusaritabi //

--- a/modular_twilight/code/modules/clothing/izuma/migrants/izumaroles.dm
+++ b/modular_twilight/code/modules/clothing/izuma/migrants/izumaroles.dm
@@ -77,7 +77,7 @@
 	beltr = /obj/item/rogueweapon/sword/short/wakizashi
 	neck = /obj/item/clothing/neck/roguetown/chaincoif/iron/kusari_zukin 
 	shirt = /obj/item/clothing/suit/roguetown/shirt/tunic/kimono 
-	head = /obj/item/clothing/head/roguetown/zurarikabutonew 
+	head = /obj/item/clothing/head/roguetown/helmet/zurarikabutonew
 	armor = /obj/item/clothing/suit/roguetown/armor/brigandine/oyoroi/oyoroigusoku 
 	pants = /obj/item/clothing/under/roguetown/chainlegs/sendan 
 	shoes = /obj/item/clothing/shoes/roguetown/boots/armor/light/kusaritabi 


### PR DESCRIPTION
## About The Pull Request
- Исправление "Зунари кабуто Изумы". Теперь он наследуется от шлема рогтауна.
   - Путь сменён с `/obj/item/clothing/head/roguetown/zurarikabutonew` на `/obj/item/clothing/head/roguetown/helmet/zurarikabutonew`.
   - Теперь шлем будет плавиться в кузне в слиток стали  и чиниться молотком.
   - Новый путь применён в местах упоминания в коде, вроде лодаутов ролей.
- Кроме этого, наследование шлема приведёт к тому, что:
   - w_class станет `normal` из `small` (Нельзя будет положить в контейнер типа сумки).
   - Шлем получит `resistance_flags = FIRE_PROOF` (Шлем не будет гореть).
   - Добавятся технические переменные вроде `sleevetype`, `sleeve`, `dynamic_hair_suffix`, `blocksound` шлема.

## Why It's Good For The Game
По [багрепорту](https://discord.com/channels/1133928966915358822/1338880396749836358/1338880396749836358). Теперь внешне стальной шлем будет чиниться кузнецом и плавиться в сталь, а не, как раньше, разбираться ножницами и чиниться ниткой.

## Proof of Testing (Required)
На локалке проверил.
